### PR TITLE
fixes: wrong namespace in silex.part2, typo in URL-link at xx.git

### DIFF
--- a/04.silex.part2.html
+++ b/04.silex.part2.html
@@ -677,9 +677,9 @@ abstract class Repository {
 						<ul>
 							<li class="fragment">
 								Example class implementation
-								<pre class="bigger"><code class="language-php">namespace Ikdoeict\Provider;
+								<pre class="bigger"><code class="language-php">namespace Ikdoeict\Repository;
 
-class TweetsRepository extends Knp\Repository {
+class TweetsRepository extends \Knp\Repository {
 	public function getTableName() { return 'tweets'; }
 }</code></pre>
 							</li>

--- a/xx.git.html
+++ b/xx.git.html
@@ -1560,7 +1560,7 @@ $ </span></code></pre>
 								Remote Git server with nifty web interface
 								<ul>
 									<li>Browse branches</li>
-									<li>Inspect commmits (<a href="ttps://github.com/bramus/ws2-sws-course-materials/commit/01a54d00633ca8627c717bdec442d322e45e67e8">example</a>)</li>
+									<li>Inspect commmits (<a href="https://github.com/bramus/ws2-sws-course-materials/commit/01a54d00633ca8627c717bdec442d322e45e67e8">example</a>)</li>
 								</ul>
 							</li>
 							<li class="fragment" style="margin-top: 1em;">


### PR DESCRIPTION
Deze commit bevat (volgens mij) twee bugfixes:
- Blijkbaar was er een typo in de URL bij het verwijzen naar de commit op GitHub (ttps in plaats van https).
- In het tweede deel van Silex wordt er in het voorbeeld een verkeerde namespace gegeven en de initialisatie van de class waarvan overgeërfd wordt is niet compleet. Er moet een "\" voorstaan, anders zal de parent-class staan in de namespace waar de overerving gebeurt.
