### PR TITLE
Update 06.silex.part4.html

### DIFF
--- a/06.silex.part4.html
+++ b/06.silex.part4.html
@@ -268,10 +268,10 @@ $numItems; // To indicate the number of items</code></pre>
 		{% endif %}
 
 		{% for page in pagination %}
-		&lt;li {% if page == curPage %} class=&quot;active&quot;{% endif %}{% if page == '...' %} class=&quot;disabled&quot;{% endif %}&gt;
+		&lt;li {% if page == curPage %} class=&quot;active&quot;{% endif %}{% if page == '..' %} class=&quot;disabled&quot;{% endif %}&gt;
 			{% if page == curPage %}
 				&lt;span&gt;{{ page }}&lt;/span&gt;
-			{% elseif page == '...' %}
+			{% elseif page == '..' %}
 				&lt;span&gt;&hellip;&lt;/span&gt;
 			{% else %}
 				&lt;a href=&quot;{{ baseUrl }}?p={{ page }}&quot; data-p=&quot;{{ page }}&quot;&gt;{{ page }}&lt;/a&gt;


### PR DESCRIPTION
To show "..." in the pagination and make it non-clickable you have to use 2 dots instead of 3 in the HTML Twig code
